### PR TITLE
Ensure native and managed runtime specific libraries are packaged correctly

### DIFF
--- a/src/Bonsai.Ximea/Bonsai.Ximea.csproj
+++ b/src/Bonsai.Ximea/Bonsai.Ximea.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <Content Include="Bonsai.Ximea.props" PackagePath="build\net472" />
-    <Content Include="$(XimeaApiPath)net472\$(XimeaApiNetFileName)" PackagePath="build\net472\bin" />
+    <Content Include="$(XimeaApiPath)net472\$(XimeaApiNetFileName)" PackagePath="build\net472\bin\x64" />
     <Content Include="$(XimeaApiNativePath)$(XimeaApiNativeFileName)" PackagePath="runtimes\win-x64\native">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>$(XimeaApiNativeFileName)</TargetPath>

--- a/src/Bonsai.Ximea/Bonsai.Ximea.props
+++ b/src/Bonsai.Ximea/Bonsai.Ximea.props
@@ -1,7 +1,7 @@
 ﻿<Project>
-  <ItemGroup Condition="'$(Platform.ToLower())' == 'x64' Or '$(Platform.ToLower())' == 'anycpu'">">
-    <Reference Include="xiApi.NET">
-      <HintPath>$(MSBuildThisFileDirectory)..\build\net472\bin\xiApi.NETX64.dll</HintPath>
+  <ItemGroup Condition="'$(Platform.ToLower())' == 'x64' Or '$(Platform.ToLower())' == 'anycpu'">
+    <Reference Include="xiApi.NETX64">
+      <HintPath>$(MSBuildThisFileDirectory)bin\x64\xiApi.NETX64.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
There are specific packaging rules that must be followed to make sure runtime specific libraries are found and correctly registered by both the Bonsai package manager and MSBuild.

The complete modern resolution protocol cannot be followed due to https://github.com/bonsai-rx/bonsai/issues/2352 and the lack of reference assemblies, and therefore we deploy a mixed strategy here which we can improve later.