### PR TITLE
Add license terms for xiAPI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -17,3 +17,64 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+This software integrates and makes use of the XIMEA Application Programming
+Interface, which is subject to the following license agreement:
+
+Copyright 2002-2024 XIMEA 
+
+License For Customer Use of XIMEA Software
+
+IMPORTANT NOTICE -- READ CAREFULLY: This License For Customer Use of XIMEA Software ("LICENSE") is the agreement which governs use of the software of XIMEA s.r.o. ("XIMEA") obtained herewith, including computer software and associated printed materials ("SOFTWARE"). By downloading, installing, copying, or otherwise using the SOFTWARE, you agree to be bound by the terms of this LICENSE. If you do not agree to the terms of this LICENSE, do not download, install or use the SOFTWARE.
+
+RECITALS
+
+Use of XIMEA's products requires three elements: the SOFTWARE, XIMEA's digital camera hardware, and a personal computer. The SOFTWARE is protected by copyright laws and international copyright treaties, as well as other intellectual property laws and treaties. The SOFTWARE is not sold, and instead is only licensed for use, strictly in accordance with this document. The hardware is sold, but this LICENSE does not cover that sale, since it may not necessarily be sold as a package with the SOFTWARE. This LICENSE sets forth the terms and conditions of the SOFTWARE LICENSE only.
+
+1. DEFINITIONS
+
+1.1 Customer. Customer means the entity or individual that downloads, installs or uses the SOFTWARE.
+
+2. GRANT OF LICENSE
+
+XIMEA reserves all rights and copyrights to all software that it has produced.
+
+2.1 Rights and Limitations of Grant. XIMEA hereby grants Customer the following non-exclusive, non-transferable right to use the SOFTWARE, with the following limitations:
+
+2.1.1 Rights. Customer may install and use as many copies of the SOFTWARE on a single computer, and may make multiple back-up copies of the Software. This LICENSE of SOFTWARE may be shared or used concurrently on different computers.
+
+2.1.2 Product. Customer may incorporate the SOFTWARE in to a commercial or non-commercial Product as long as such Product contains all SOFTWARE component parts in their original and unmodified form.
+
+2.1.3 Limitations.
+
+No Reverse Engineering. Customer may not reverse engineer, decompile, or disassemble the SOFTWARE, nor attempt in any other manner to obtain the source code.
+
+No Rental. Customer may not rent or lease the SOFTWARE to someone else.
+
+No Modification. Customer may not change, patch, translate or otherwise modify the SOFTWARE and its component parts.
+
+3. TERMINATION
+
+This LICENSE will automatically terminate if Customer fails to comply with any of the terms and conditions hereof. In such event, Customer must destroy all copies of the SOFTWARE and all of its component parts.
+
+Defensive Suspension. If Customer commences or participates in any legal proceeding against XIMEA, then XIMEA may, in its sole discretion, suspend or terminate all license grants and any other rights provided under this LICENSE during the pendency of such legal proceedings.
+
+4. COPYRIGHT
+
+All title and copyrights in and to the SOFTWARE (including but not limited to all images, text, and other information incorporated into the SOFTWARE), and any copies of the SOFTWARE, are owned by XIMEA, or its suppliers. The SOFTWARE is protected by copyright laws and international treaty provisions. Accordingly, Customer is required to treat the SOFTWARE like any other copyrighted material, except as otherwise allowed pursuant to this license.
+
+5. APPLICABLE LAW
+
+This LICENSE shall be deemed to have been made in, and shall be construed pursuant to, the laws of Slovak Republic.
+
+6. DISCLAIMER OF WARRANTIES AND LIMITATION ON LIABILITY
+
+6.1 No Warranties. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE SOFTWARE IS PROVIDED "AS IS" AND XIMEA AND ITS SUPPLIERS DISCLAIM ALL WARRANTIES, EITHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+6.2 No Liability for Consequential Damages. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL XIMEA OR ITS SUPPLIERS BE LIABLE FOR ANY SPECIAL, INCIDENTAL, INDIRECT, OR CONSEQUENTIAL DAMAGES WHATSOEVER (INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF BUSINESS PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION, OR ANY OTHER PECUNIARY LOSS) ARISING OUT OF THE USE OF OR INABILITY TO USE THE SOFTWARE, EVEN IF XIMEA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. MISCELLANEOUS
+
+If any provision of this LICENSE is inconsistent with, or cannot be fully enforced under, the law, such provision will be construed as limited to the extent necessary to be consistent with and fully enforceable under the law. This LICENSE is the final, complete and exclusive agreement between the parties relating to the subject matter hereof, and supersedes all prior or contemporaneous understandings and agreements relating to such subject matter, whether oral or written. This LICENSE may only be modified in writing signed by an authorized officer of XIMEA.

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,4 +81,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Ximea` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/ximea).
+`Bonsai.Ximea` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/ximea). `Bonsai.Ximea` integrates and makes use of the XIMEA Application Programming Interface, which is subject to the License For Customer Use of XIMEA Software.


### PR DESCRIPTION
This package integrates and makes use of the XIMEA Application Programming Interface, which is subject to the License For Customer Use of XIMEA Software. Although not strictly required for incorporation under their license terms, we add them to the package license for consistency with other camera packages.